### PR TITLE
test retryWrites option with servers that don't support it

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -296,7 +296,7 @@ functions:
         working_dir: "mongoc"
         script: |
           set -o errexit
-          COMPRESSORS="${COMPRESSORS}" CC="${CC}" AUTH=${AUTH} SSL=${SSL} URI=${URI} IPV4_ONLY=${IPV4_ONLY} VALGRIND=${VALGRIND} sh .evergreen/run-tests.sh
+          COMPRESSORS="${COMPRESSORS}" CC="${CC}" AUTH=${AUTH} SSL=${SSL} URI=${URI} IPV4_ONLY=${IPV4_ONLY} VALGRIND=${VALGRIND} MONGOC_TEST_URI=${URI} sh .evergreen/run-tests.sh
 
   "run auth tests":
     - command: shell.exec
@@ -1061,6 +1061,40 @@ tasks:
               set -o xtrace
               DEBUG=yes CC='${CC}' MARCH='${MARCH}' SASL=sspi SSL=winssl sh .evergreen/compile.sh
         - func: "upload build"
+
+    # Verify that retryWrites=true is ignored with standalone
+    - name: retry-true-latest-server
+      depends_on:
+        - name: "debug-compile-sasl-openssl"
+      commands:
+        - func: "fetch build"
+          vars:
+            BUILD_NAME: "debug-compile-sasl-openssl"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "latest"
+            TOPOLOGY: "server"
+        - func: "run tests"
+          vars:
+            AUTH: "noauth"
+            URI: "mongodb://localhost/?retryWrites=true"
+
+    # Verify that retryWrites=true is ignored with old server
+    - name: retry-true-3.4-replica-set
+      depends_on:
+        - name: "debug-compile-sasl-openssl"
+      commands:
+        - func: "fetch build"
+          vars:
+            BUILD_NAME: "debug-compile-sasl-openssl"
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "3.4"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
+          vars:
+            AUTH: "noauth"
+            URI: "mongodb://localhost/?replicaSet=repl0&retryWrites=true"
 
 # }}}
 
@@ -6655,9 +6689,11 @@ buildvariants:
     - ".authentication-tests .openssl"
     - ".latest .openssl !.nosasl .server"
     - ".latest .nossl !.nosasl"
+    - "retry-true-3.4-replica-set"
+    - "retry-true-latest-server"
+    # Ubuntu16.04 only supports MongoDB 3.4+
     - ".3.4 .openssl !.nosasl .server"
     - ".3.4 .nossl !.nosasl"
-      # Ubuntu16.04 only supports MongoDB 3.4+
 
 - name: darwin
   display_name: "*Darwin, macOS (Apple LLVM)"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -9,6 +9,9 @@ SSL=${SSL:-nossl}
 URI=${URI:-}
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 DNS=${DNS:-nodns}
+
+echo "COMPRESSORS='${COMPRESSORS}' CC='${CC}' AUTH=${AUTH} SSL=${SSL} URI=${URI} IPV4_ONLY=${IPV4_ONLY} VALGRIND=${VALGRIND} MONGOC_TEST_URI=${MONGOC_TEST_URI}"
+
 [ -z "$MARCH" ] && MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 TEST_ARGS="-d -F test-results.json"
 

--- a/src/mongoc/mongoc-cmd.c
+++ b/src/mongoc/mongoc-cmd.c
@@ -459,7 +459,7 @@ _largest_cluster_time (const bson_t *a, const bson_t *b)
  * retryable if executed via mongoc_client_write_command_with_opts(); however,
  * documentation already instructs users not to use that for basic writes.
  */
-static bool
+static mongoc_cmd_parts_allow_txn_number_t
 _allow_txn_number (const mongoc_cmd_parts_t *parts,
                    const mongoc_server_stream_t *server_stream)
 {
@@ -468,18 +468,18 @@ _allow_txn_number (const mongoc_cmd_parts_t *parts,
                 MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_UNKNOWN);
 
    if (!parts->is_write_command) {
-      return false;
+      return MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_NO;
    }
 
    if (server_stream->sd->max_wire_version < WIRE_VERSION_RETRY_WRITES) {
-      return false;
+      return MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_NO;
    }
 
    if (!strcasecmp (parts->assembled.command_name, "findandmodify")) {
-      return true;
+      return MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_YES;
    }
 
-   return false;
+   return MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_NO;
 }
 
 

--- a/tests/TestSuite.h
+++ b/tests/TestSuite.h
@@ -51,7 +51,7 @@ extern "C" {
 #define CERT_CLIENT CERT_TEST_DIR "/client.pem"
 #define CERT_ALTNAME                                                   \
    CERT_TEST_DIR "/altname.pem"             /* alternative.mongodb.org \
-                                               */
+                                             */
 #define CERT_WILD CERT_TEST_DIR "/wild.pem" /* *.mongodb.org */
 #define CERT_COMMONNAME \
    CERT_TEST_DIR "/commonName.pem"                /* 127.0.0.1 & localhost */
@@ -282,29 +282,33 @@ test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       }                                                            \
    } while (0)
 
-#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)               \
-   do {                                                                      \
-      if (error.domain != _domain) {                                         \
-         fprintf (stderr,                                                    \
-                  "%s:%d %s(): error domain %d doesn't match expected %d\n", \
-                  __FILE__,                                                  \
-                  __LINE__,                                                  \
-                  BSON_FUNC,                                                 \
-                  error.domain,                                              \
-                  _domain);                                                  \
-         abort ();                                                           \
-      };                                                                     \
-      if (error.code != _code) {                                             \
-         fprintf (stderr,                                                    \
-                  "%s:%d %s(): error code %d doesn't match expected %d\n",   \
-                  __FILE__,                                                  \
-                  __LINE__,                                                  \
-                  BSON_FUNC,                                                 \
-                  error.code,                                                \
-                  _code);                                                    \
-         abort ();                                                           \
-      };                                                                     \
-      ASSERT_CONTAINS (error.message, _message);                             \
+#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)              \
+   do {                                                                     \
+      if (error.domain != _domain) {                                        \
+         fprintf (stderr,                                                   \
+                  "%s:%d %s(): error domain %d doesn't match expected %d\n" \
+                  "error: \"%s\"",                                          \
+                  __FILE__,                                                 \
+                  __LINE__,                                                 \
+                  BSON_FUNC,                                                \
+                  error.domain,                                             \
+                  _domain,                                                  \
+                  error.message);                                           \
+         abort ();                                                          \
+      };                                                                    \
+      if (error.code != _code) {                                            \
+         fprintf (stderr,                                                   \
+                  "%s:%d %s(): error code %d doesn't match expected %d\n"   \
+                  "error: \"%s\"",                                          \
+                  __FILE__,                                                 \
+                  __LINE__,                                                 \
+                  BSON_FUNC,                                                \
+                  error.code,                                               \
+                  _code,                                                    \
+                  error.message);                                           \
+         abort ();                                                          \
+      };                                                                    \
+      ASSERT_CONTAINS (error.message, _message);                            \
    } while (0);
 
 #define ASSERT_CAPTURED_LOG(_info, _level, _msg)                \
@@ -495,7 +499,10 @@ TestSuite_AddLive (TestSuite *suite, const char *name, TestFunc func);
 int
 TestSuite_CheckMockServerAllowed (void);
 void
-_TestSuite_AddMockServerTest (TestSuite *suite, const char *name, TestFunc func, ...);
+_TestSuite_AddMockServerTest (TestSuite *suite,
+                              const char *name,
+                              TestFunc func,
+                              ...);
 #define TestSuite_AddMockServerTest(_suite, _name, ...) \
    _TestSuite_AddMockServerTest (_suite, _name, __VA_ARGS__, NULL)
 void


### PR DESCRIPTION
Test this with "evergreen  patch -p mongo-c-driver -t all -v gcc53 -f -y".

I expect it will pass, or mostly pass, once this is merged:
https://github.com/jmikola/mongo-c-driver/pull/4